### PR TITLE
Template

### DIFF
--- a/openapi-python-templates/api.mustache
+++ b/openapi-python-templates/api.mustache
@@ -115,8 +115,8 @@ class _{{classname}}:
             {{#queryParams.0}}params=query_params,{{/queryParams.0}}
             {{#headerParams.0}}headers=headers,{{/headerParams.0}}
             {{#cookieParams.0}}cookies=cookies,{{/cookieParams.0}}
-            {{#formParams.0}}data=data,{{/formParams.0}}
-            {{#fileParams.0}}files=files,{{/fileParams.0}}
+            {{#formParams.0}}data=data,
+            files=files{{/formParams.0}}
             {{#bodyParam}}json=body,{{/bodyParam}}
         )
 

--- a/openapi-python-templates/api.mustache
+++ b/openapi-python-templates/api.mustache
@@ -50,7 +50,7 @@ class _{{classname}}:
 {{#queryParams}}
 {{^required}}
         if {{paramName}} is not None:
-            query_params["{{baseName}}"] = str({{paramName}})
+            query_params["{{baseName}}"] = {{#isListContainer}}[str({{paramName}}_item) for {{paramName}}_item in {{paramName}}]{{/isListContainer}}{{^isListContainer}}str({{paramName}}){{/isListContainer}}
 {{/required}}
 {{/queryParams}}
 

--- a/openapi-python-templates/api.mustache
+++ b/openapi-python-templates/api.mustache
@@ -116,7 +116,7 @@ class _{{classname}}:
             {{#headerParams.0}}headers=headers,{{/headerParams.0}}
             {{#cookieParams.0}}cookies=cookies,{{/cookieParams.0}}
             {{#formParams.0}}data=data,
-            files=files{{/formParams.0}}
+            files=files or None{{/formParams.0}}
             {{#bodyParam}}json=body,{{/bodyParam}}
         )
 

--- a/openapi-python-templates/api_client.mustache
+++ b/openapi-python-templates/api_client.mustache
@@ -34,7 +34,7 @@ class ApiClient:
     def __init__(self, host: str = None, **kwargs: Any) -> None:
         self.host = host
         self.middleware: MiddlewareT = BaseMiddleware()
-        self._async_client = AsyncClient()
+        self._async_client = AsyncClient(**kwargs)
 
     @overload
     async def request(


### PR DESCRIPTION
Misc fixes 
- files weren't getting passed to multipart form apis
- ApiClient constructor passes kwargs to its AsyncClient allowing e.g. timeouts to be set.
- queries didn't handle lists, so tag=['1','2','3'] wasn't converted to &tag=1&tag=2&tag=3
