### PR TITLE
Map {}, None or Any to Any instead of object

### DIFF
--- a/openapi-python-templates/model.mustache
+++ b/openapi-python-templates/model.mustache
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional, List
+from typing import Any  # noqa
 from typing_extensions import Literal
 from uuid import UUID
 from pydantic import BaseModel, Schema

--- a/scripts/util/openapi-generate.sh
+++ b/scripts/util/openapi-generate.sh
@@ -49,7 +49,7 @@ generate_in_docker() {
     --package-name="${PACKAGE_NAME}" \
     --additional-properties=generateSourceCodeOnly=true \
     -t /local/openapi-python-templates \
-    --type-mappings array=List,uuid=UUID,file=IO \
+    --type-mappings array=List,uuid=UUID,file=IO,object=Any \
     "$@"
 }
 


### PR DESCRIPTION
APIs with a response schema of {} were translated to returning object, which causes a validation fail. 

Mapping to Any fixes this, I'm not sure this is the best solution.
