### PR TITLE
Fix for enum.Enum subclasses

### DIFF
--- a/openapi-python-templates/__init__package.mustache
+++ b/openapi-python-templates/__init__package.mustache
@@ -1,4 +1,5 @@
 import inspect
+from pydantic import BaseModel
 
 from @IMPORT_NAME@ import models
 from @IMPORT_NAME@.api_client import ApiClient, AsyncApis, SyncApis  # noqa F401
@@ -7,4 +8,5 @@ from @IMPORT_NAME@.api_client import ApiClient, AsyncApis, SyncApis  # noqa F401
 for model in inspect.getmembers(models, inspect.isclass):
 	if model[1].__module__ == "@IMPORT_NAME@.models":
 		model_class = model[1]
-		model_class.update_forward_refs()
+		if isinstance(model_class, BaseModel):
+			model_class.update_forward_refs()

--- a/openapi-python-templates/model.mustache
+++ b/openapi-python-templates/model.mustache
@@ -7,6 +7,18 @@ from pydantic import BaseModel, Field
 
 {{#models}}
 {{#model}}
+
+{{#allowableValues}}
+from enum import Enum
+
+class {{classname}}(str, Enum):
+{{#enumVars}}
+    {{name}} = {{{value}}}{{^-last}}
+{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+
+{{^allowableValues}}
 class {{classname}}(BaseModel):
 {{#vars}}
 {{#isEnum}}
@@ -16,5 +28,7 @@ class {{classname}}(BaseModel):
     {{name}}: "{{^required}}Optional[{{/required}}{{>_dataTypeModel}}{{^required}}]{{/required}}" = Field({{#required}}...{{/required}}{{^required}}None{{/required}}, alias="{{baseName}}")
 {{/isEnum}}
 {{/vars}}
+{{/allowableValues}}
+
 {{/model}}
 {{/models}}


### PR DESCRIPTION
Hi, 
I faced the same issue reported in [this issue](https://github.com/dmontagu/fastapi_client/issues/17).
The solution uses another template branch for enum types.
The schema definition for the model looks like:
```
    Method:
      title: Method
      enum:
      - One
      - Two
      - Three
      type: string
      description: An enumeration.
```
And the expectation for the generated pydantic model:
```
class Method(str, Enum):
    ONE = "One"
    TWO = "Two"
    THREE = "Three"
```
Please, take a look at the changes I made.

Thanks.
Kostya.